### PR TITLE
Use Object.assign instead of xtend

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 /* global MessageChannel Notification */
-var mutate = require('xtend/mutable')
 var assert = require('assert')
 
 module.exports = serviceWorker
@@ -27,7 +26,7 @@ function serviceWorker (name, opts) {
     assert.equal(typeof emitter, 'object', 'choo-service-worker: emitter should be type object')
 
     emitter.on(state.events.DOMCONTENTLOADED, function () {
-      opts = mutate({ scope: '/' }, opts)
+      opts = Object.assign({ scope: '/' }, opts)
       // electron support
       if (opts.electron) {
         var path = require('path')

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "start": "bankai -A 0.0.0.0 -a . example.js",
     "test": "standard && npm run deps"
   },
-  "dependencies": {
-    "xtend": "^4.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "bankai": "^8.1.1",
     "choo": "^6.0.0",


### PR DESCRIPTION
Removing xtend to keep in line with choo dropping it in favor of `Object.assing` (https://github.com/choojs/choo/pull/616).